### PR TITLE
Development Push: migrate sqlite to Mysql 20-August-2022

### DIFF
--- a/bookstore/settings.py
+++ b/bookstore/settings.py
@@ -85,10 +85,19 @@ if os.environ.get('DATABASE_URL'):
         'default' : dj_database_url.config(conn_max_age=500)
     }    
 else:
+    # DATABASES = {
+    #     'default': {
+    #     'ENGINE': 'django.db.backends.sqlite3',
+    #     'NAME': BASE_DIR / 'db.sqlite3',
+    # }
     DATABASES = {
-        'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'books_mysql',
+        'USER': 'george',
+        'PASSWORD': '2526',
+        'HOST': 'localhost',
+        'PORT': '3306',
     }
 }
 
@@ -123,7 +132,6 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
### General

- Notes:
Change the small sqlite3 database to Mysql.

### Features

- Migrate sqlite to Mysql (4f7194f90d11da3156fea6a37ed1b1705b9a3880)


